### PR TITLE
Sample config and sample data provider fix

### DIFF
--- a/config/nova-calendar.php
+++ b/config/nova-calendar.php
@@ -26,7 +26,7 @@ return [
            Don't forget to add the proper use statement above.
            This key is required.
          */
-        'dataProvider' => CalendarDataProvider::class
+        'dataProvider' => CalendarDataProvider::class,
 
         /*
          * URI for this Nova Calendar (will be appended to the Nova path, /nova by default)

--- a/resources/CalendarDataProvider.default.php
+++ b/resources/CalendarDataProvider.default.php
@@ -2,11 +2,11 @@
 
 namespace App\Providers;
 
-use Wdelfuego\NovaCalendar\DataProvider\AbstractDataProvider;
+use Wdelfuego\NovaCalendar\DataProvider\AbstractCalendarDataProvider;
 use Wdelfuego\NovaCalendar\Event;
 use App\Nova\User;
 
-class CalendarDataProvider extends AbstractDataProvider
+class CalendarDataProvider extends AbstractCalendarDataProvider
 {
     //
     // Add the Nova resources that should be displayed on the calendar to this method


### PR DESCRIPTION
- Missing comma fix in sample nova-calendar.php config file
- Extended class name fix in sample CalendarDataPrivider (should be: AbstractCalendarDataProvider instead of AbstractDataProvider)